### PR TITLE
Added fix for Coud9 warnings

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,3 +1,6 @@
+// quick fix for Cloud9 warning:
+/* global $ */
+
 // Class 2:
 // Complete displayList() to show a single song in the list
 


### PR DESCRIPTION
Without this change, Cloud9 adds ⚠️ icons everytime a student uses `$`.